### PR TITLE
Add basic FastAPI app and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,19 @@ Autenticación o integración con Slack/Meet
 
 ---
 
-🧪 Cómo correrlo
+## 🧪 Cómo correrlo
 
-A completar cuando esté el primer código disponible.
+1. Instalar dependencias:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+2. Ejecutar el servidor:
+
+```bash
+uvicorn src.main:app --reload
+```
 
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hola desde RetroIA"}


### PR DESCRIPTION
## Summary
- scaffold basic FastAPI application with root endpoint
- declare FastAPI and Uvicorn dependencies
- document install and run steps

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e1d5378c83318eb92436bab828b0